### PR TITLE
Fixed interface to not need the Entry datatype prebuilt, accepts pairs again

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Usage:
 > names = ["Rep. Meg Mueller","Twana Jacobs","Sammie Paucek"]
 
 > targets = zip names [1..] --Stand-in for your UIDs
-
 > qs = buildQuickSearch targets
 
 -- Scorer can be any func of type (T.Text -> T.Text -> Ratio Int)
@@ -74,8 +73,7 @@ scorer :: (T.Text -> T.Text -> Ratio Int)
 
 > oneShotTopNMatches 5 names targets scorer
 ```
-which will return a list of `(entry, [(score, target)])`, where `target`s
-are the found names and their UIDs with the highest match score.
+which will return a list of `(Entry uid1, Scored (Entry uid2))`
 
 `topNMatches` and `matchesWithThreshold` have one-shot batch versions, named
 `oneShotTopNMatches` and `oneShotMatchesWithThreshold` respectively. Like the

--- a/src/QuickSearch.hs
+++ b/src/QuickSearch.hs
@@ -24,13 +24,24 @@ import           QuickSearch.Filter
 import           QuickSearch.MatchAndScore
 
 -- | Given a list of entries to be searched, create a QuickSearch object.
-buildQuickSearch
+rawBuildQuickSearch
   :: (Hashable uid, Eq uid)
   => [Entry uid] -- ^ List of entries to be searched
   -> QuickSearch uid -- ^ QuickSearch object holding token partitions
-buildQuickSearch entries =
+rawBuildQuickSearch entries =
   let tokenFilter = buildTokenPartitions entries
   in  QuickSearch entries tokenFilter
+
+-- | Given a list of pairs of (T.Text, uid) to be searched,
+-- create a QuickSearch object.
+buildQuickSearch
+  :: (Hashable uid, Eq uid)
+  => [(T.Text, uid)] -- ^ List of entries to be searched
+  -> QuickSearch uid -- ^ QuickSearch object holding token partitions
+buildQuickSearch entries =
+  let entries' = map (uncurry Entry) entries
+      tokenFilter = buildTokenPartitions entries'
+  in  QuickSearch entries' tokenFilter
 
 -- | Given a QuickSearch object, scorer, and string, return the top N matches.
 topNMatches

--- a/src/QuickSearch/Filter.hs
+++ b/src/QuickSearch/Filter.hs
@@ -28,9 +28,6 @@ data Entry uid = Entry {
 first :: (T.Text -> T.Text) -> Entry uid -> Entry uid
 first f entry = Entry (f . entryName $ entry) (entryUID entry)
 
-second :: (uid -> uid) -> Entry uid -> Entry uid
-second f entry = Entry (entryName entry) (f . entryUID $ entry)
-
 toTokenizedTuple :: (Hashable uid, Eq uid) => Entry uid -> ([Token], uid)
 toTokenizedTuple = getTokens . entryName &&& entryUID
 

--- a/src/QuickSearch/OneShot.hs
+++ b/src/QuickSearch/OneShot.hs
@@ -22,23 +22,23 @@ oneShot
   => (QuickSearch uid2 -> Int -> Scorer -> T.Text -> [Scored (Entry uid2)])
   -- ^ Match retrieval function to be converted into a one-shot
   -> Int -- ^ The reference number for the match retrieval function.
-  -> [Entry uid1] -- ^ List of entries to be processed
-  -> [Entry uid2] -- ^ List of entries making up the search space
+  -> [(T.Text, uid1)] -- ^ List of entries to be processed
+  -> [(T.Text, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(Entry uid1, [Scored (Entry uid2)])]
     -- ^ List of entries and their matches.
 oneShot f n entries targets scorer =
   let qs      = buildQuickSearch targets
-      results = map (f qs n scorer . entryName) entries
-  in  zip entries results
+      results = map (f qs n scorer . fst) entries
+  in  zip (map (uncurry Entry) entries) results
 
 -- | One-shot version of topNMatches. Builds the QuickSearch in the background
 -- and discards it when finished.
 oneShotTopNMatches
   :: (Hashable uid1, Eq uid1, Hashable uid2, Eq uid2)
   => Int -- ^ N: Number of matches to return
-  -> [Entry uid1] -- ^ List of entries to be processed
-  -> [Entry uid2] -- ^ List of entries making up the search space
+  -> [(T.Text, uid1)] -- ^ List of entries to be processed
+  -> [(T.Text, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(Entry uid1, [Scored (Entry uid2)])]
   -- ^ List of entries and up to N of the best matches.
@@ -49,8 +49,8 @@ oneShotTopNMatches = oneShot topNMatches
 oneShotMatchesWithThreshold
   :: (Hashable uid1, Eq uid1, Hashable uid2, Eq uid2)
   => Int -- ^ Score threshold above which to return matches
-  -> [Entry uid1] -- ^ List of entries to be processed
-  -> [Entry uid2] -- ^ List of entries making up the search space
+  -> [(T.Text, uid1)] -- ^ List of entries to be processed
+  -> [(T.Text, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(Entry uid1, [Scored (Entry uid2)])]
   -- ^ List of entries and their matches above the score threshold.

--- a/src/QuickSearch/String.hs
+++ b/src/QuickSearch/String.hs
@@ -35,9 +35,6 @@ data SEntry uid = SEntry {
 first :: (String -> String) -> SEntry uid -> SEntry uid
 first f entry = SEntry (f . sEntryName $ entry) (sEntryUID entry)
 
-second :: (uid -> uid) -> SEntry uid -> SEntry uid
-second f entry = SEntry (sEntryName entry) (f . sEntryUID $ entry)
-
 stringEntryToEntry :: (Hashable uid, Eq uid) => SEntry uid -> Entry uid
 stringEntryToEntry = uncurry Entry . (T.pack . sEntryName &&& sEntryUID)
 
@@ -65,13 +62,24 @@ scoredTextToString scoredSEntry = Scored score textEntry
     textEntry = entryToStringEntry entry
 
 -- | Given a list of entries to be searched, create a QuickSearch object.
-buildQuickSearch
+rawBuildQuickSearch
   :: (Hashable uid, Eq uid)
   => [SEntry uid] -- ^ List of entries to be searched
   -> QuickSearch uid -- ^ QuickSearch object holding token partitions
-buildQuickSearch entries =
+rawBuildQuickSearch entries =
   let stringToText = T.pack . sEntryName
       entries' = map stringEntryToEntry entries
+      tokenFilter = buildTokenPartitions entries'
+  in  QuickSearch entries' tokenFilter
+
+-- | Given a list of pairs of (String, uid) to be searched,
+-- create a QuickSearch object.
+buildQuickSearch
+  :: (Hashable uid, Eq uid)
+  => [(String, uid)] -- ^ List of entries to be searched
+  -> QuickSearch uid -- ^ QuickSearch object holding token partitions
+buildQuickSearch entries =
+  let entries' = map (stringEntryToEntry . uncurry SEntry) entries
       tokenFilter = buildTokenPartitions entries'
   in  QuickSearch entries' tokenFilter
 

--- a/src/QuickSearch/String/OneShot.hs
+++ b/src/QuickSearch/String/OneShot.hs
@@ -23,23 +23,23 @@ oneShot
   => (QuickSearch uid2 -> Int -> Scorer -> String -> [Scored (SEntry uid2)])
   -- ^ Match retrieval function to be converted into a one-shot
   -> Int -- ^ The reference number for the match retrieval function.
-  -> [SEntry uid1] -- ^ List of entries to be processed
-  -> [SEntry uid2] -- ^ List of entries making up the search space
+  -> [(String, uid1)] -- ^ List of entries to be processed
+  -> [(String, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(SEntry uid1, [Scored (SEntry uid2)])]
     -- ^ List of entries and their matches.
 oneShot f n entries targets scorer =
   let qs      = buildQuickSearch targets
-      results = map (f qs n scorer . sEntryName) entries
-  in  zip entries results
+      results = map (f qs n scorer . fst) entries
+  in  zip (map (uncurry SEntry) entries) results
 
 -- | One-shot version of topNMatches. Builds the QuickSearch in the background
 -- and discards it when finished.
 oneShotTopNMatches
   :: (Hashable uid1, Eq uid1, Hashable uid2, Eq uid2)
   => Int -- ^ N: Number of matches to return
-  -> [SEntry uid1] -- ^ List of entries to be processed
-  -> [SEntry uid2] -- ^ List of entries making up the search space
+  -> [(String, uid1)] -- ^ List of entries to be processed
+  -> [(String, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(SEntry uid1, [Scored (SEntry uid2)])]
   -- ^ List of entries and up to N of the best matches.
@@ -50,8 +50,8 @@ oneShotTopNMatches = oneShot topNMatches
 oneShotMatchesWithThreshold
   :: (Hashable uid1, Eq uid1, Hashable uid2, Eq uid2)
   => Int -- ^ Score threshold above which to return matches
-  -> [SEntry uid1] -- ^ List of entries to be processed
-  -> [SEntry uid2] -- ^ List of entries making up the search space
+  -> [(String, uid1)] -- ^ List of entries to be processed
+  -> [(String, uid2)] -- ^ List of entries making up the search space
   -> Scorer -- ^ Similarity function with type (Text -> Text -> Ratio Int)
   -> [(SEntry uid1, [Scored (SEntry uid2)])]
   -- ^ List of entries and their matches above the score threshold.


### PR DESCRIPTION
There's also a `rawBuildQuickSearch` function for if your data is already formatted as `Entry`s or `SEntry`s